### PR TITLE
3: Tasksテーブル用マイグレーションファイルとシーダーファイルの作成

### DIFF
--- a/src/database/migrations/2025_08_30_063604_create_tasks_table.php
+++ b/src/database/migrations/2025_08_30_063604_create_tasks_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tasks', function (Blueprint $table) {
+            $table->id();   //unsigned big int,primary key,auto increment
+            $table->string('title', 24);
+            $table->string('content', 255)->nullable();
+            $table->unsignedBigInteger('genre_id')->nullable()->index();
+            $table->unsignedBigInteger('owner_id')->index()->comment('タスク所有者ID');
+            $table->string('rrule', 255)->nullable();
+            $table->timestamp('start_at')->index();
+            $table->timestamp('end_at')->index();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tasks');
+    }
+};

--- a/src/database/seeders/DatabaseSeeder.php
+++ b/src/database/seeders/DatabaseSeeder.php
@@ -13,5 +13,6 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         $this->call(UsersTableSeeder::class);
+        $this->call(TasksTableSeeder::class);
     }
 }

--- a/src/database/seeders/TasksTableSeeder.php
+++ b/src/database/seeders/TasksTableSeeder.php
@@ -2,7 +2,6 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Seeder;
 

--- a/src/database/seeders/TasksTableSeeder.php
+++ b/src/database/seeders/TasksTableSeeder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Seeder;
+
+class TasksTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        DB::table('tasks')->insert([
+            'title' => 'Test Task',
+            'content' => 'タスクをテスト入力',
+            'genre_id' => null,
+            'owner_id' => 1,
+            'rrule' => null,
+            'start_at' => '2025-09-01 09:00:00',
+            'end_at' => '2025-09-07 09:00:00',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}


### PR DESCRIPTION
## チケット名
[3: tasksテーブルとダミーデータ作成](https://project-todo-list.atlassian.net/jira/software/projects/KAN/list?selectedIssue=KAN-3)

## 対応内容
- マイグレーション
  - tasksファイル追加
- シーダー
  - tasks用ダミーデータ作成

## 証跡（スクリーンショット）
<img width="969" height="783" alt="image" src="https://github.com/user-attachments/assets/eef52ca8-aea7-4afc-bdd1-946f5cda564c" />
<img width="854" height="654" alt="image" src="https://github.com/user-attachments/assets/ac3bf345-b46f-4097-a16a-5e9ba2c94799" />

## 申し送り事項
最新のdevelopから派生させてブランチを作成する方法の確認がしたいです。
php artisan db:seedコマンドを入力した際、UsersTableSeederにおいて同じアドレスで登録しようとしているというエラーが起こったため、php artisan db:seed --class=TasksTableSeederで今回該当するファイルを指定して処理を行いました。